### PR TITLE
Remove object_types

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -13,247 +13,131 @@
   "tags": [
     {
       "key": "diet:vegan",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "diet:vegan",
       "value": "only",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "icon_url": "https://imgplaceholder.com/64x64/72af26/ffffff/fa-dot-circle-o"
     },
     {
       "key": "diet:vegan",
       "value": "yes",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "icon_url": "https://imgplaceholder.com/64x64/72af26/ffffff/fa-circle"
     },
     {
       "key": "diet:vegetarian",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "diet:vegetarian",
       "value": "only",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "icon_url": "https://imgplaceholder.com/64x64/728224/ffffff/fa-circle-thin"
     },
     {
       "key": "diet:vegetarian",
       "value": "yes",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "icon_url": "https://imgplaceholder.com/64x64/728224/ffffff/fa-circle-o"
     },
     {
       "key": "diet:vegetarian",
       "value": "no",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "icon_url": "https://imgplaceholder.com/64x64/d63e2a/ffffff/fa-ban"
     },
     {
       "key": "shop",
       "value": "bakery",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🥖 Displayed as an emoji in tooltip"
     },
     {
       "key": "shop",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🛒 Displayed as an emoji in tooltip"
     },
     {
       "key": "craft",
       "value": "caterer",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🍴 Displayed as an emoji in tooltip"
     },
     {
       "key": "amenity",
       "value": "fast_food",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🍔 Displayed as an emoji in tooltip"
     },
     {
       "key": "amenity",
       "value": "restaurant",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🍴 Displayed as an emoji in tooltip"
     },
     {
       "key": "amenity",
       "value": "cafe",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🍵 Displayed as an emoji in tooltip"
     },
     {
       "key": "amenity",
       "value": "bar",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🍸 Displayed as an emoji in tooltip"
     },
     {
       "key": "amenity",
       "value": "pub",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🍺 Displayed as an emoji in tooltip"
     },
     {
       "key": "amenity",
       "value": "ice_cream",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "🍨 Displayed as an emoji in tooltip"
     },
     {
       "key": "contact:phone",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup if ‘phone’ tag is not present"
     },
     {
       "key": "phone",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "contact:website",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup if ‘website’ tag is not present"
     },
     {
       "key": "website",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "addr:housenumber",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "addr:street",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "addr:city",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "addr:postcode",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "addr:country",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "cuisine",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "takeaway",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "opening_hours",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in popup"
     },
     {
       "key": "name",
-      "object_types": [
-        "node",
-        "area"
-      ],
       "description": "Displayed in tooltip and in popup"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2062,9 +2062,9 @@ inherits@2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
+  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
 
 interpret@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
It is not necessary to specify object_types. The Overpass query asks for all object_types (nwr):

```javascript
const overpassQuery = 'nwr({{bbox}})[~"^diet:.*$"~"."];out center;';
```

 The documentation for taginfo [1] says:
> *If there is no 'object_types' array, all types are allowed.*.  *If there is no 'object_types' array, all types are allowed.*. 

Without these tags, the file is also clearer.


[1] https://wiki.openstreetmap.org/wiki/Taginfo/Projects