### PR TITLE
Generalize OK/not-OK logic for POIs tags.

### DIFF
--- a/js/poi.js
+++ b/js/poi.js
@@ -19,13 +19,40 @@ export default class POI {
     }
 
     /**
+     * Check if a tag for a given key and optional subkey has the `yes` or `only` values.
+     * @param {string} key
+     * @param {string} subkey
+     * @return {Boolean}
+     */
+    isOK(key, subkey) {
+       var tag = key;
+        if (subkey) {
+          tag += ':' + subkey;
+        }
+        return !!(this.tags[tag] && (this.tags[tag] === 'yes' || this.tags[key] === 'only'));
+    }
+
+    /**
+     * Check if a tag for a given key and subkey has the `no` value set.
+     * @param {string} key
+     * @param {string} subkey
+     * @return {Boolean}
+     */
+    isNotOK(key, subkey) {
+        var tag = key;
+        if (subkey) {
+          tag += ':' + subkey;
+        }
+        return !!(this.tags[key] && this.tags[key] === 'no');
+    }
+
+    /**
      * Check if a POI is OK for the specified diet.
      * @param  {string}  diet Diet (vegan, vegetarian)
      * @return {Boolean}
      */
     isDiet(diet) {
-        const key = 'diet:' + diet;
-        return !!(this.tags[key] && (this.tags[key] === 'yes' || this.tags[key] === 'only'));
+        return this.isOK('diet', diet);
     }
 
     /**
@@ -34,8 +61,7 @@ export default class POI {
      * @return {Boolean}
      */
     isNotDiet(diet) {
-        const key = 'diet:' + diet;
-        return !!(this.tags[key] && this.tags[key] === 'no');
+        return this.isNotOK('diet', diet);
     }
 
     /**


### PR DESCRIPTION
This commit creates two little shim functions called `isOK` and
`isNotOK` that check a given element's tag values for either `yes` or
`only` in the case of the former function and for the presence of a
`no` tag value in the case of the latter. These two functions can then
be called by `isDiet()` and `isNotDiet()` directly without changing the
logic or interface of the rest of the project. So what's the point?

By including these additional more generic methods, code can be more
easily reused for other elements, such as for whether an element has a
`toilets:unisex=yes` tag or other such value either in the future in
this own codebase or in forked codebases such as the (new!)
OpenToiletMap project, which is forked from here.