### PR TITLE
Add more rows to marker pop-ups, especially for toilet metadata.

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -13,6 +13,8 @@ export default class Popup {
      * @param {string} tags.shop
      * @param {string} tags.cuisine
      * @param {string} tags.takeaway
+     * @param {string} tags.toilets
+     * @param {string} tags.changing_table
      * @param {string} tags.description
      * @param {string} tags.opening_hours
      * @param {string} tags.phone
@@ -66,13 +68,21 @@ export default class Popup {
      * Generate a row to display in a marker popup.
      * @param  {string} name  Name of the property
      * @param  {string} value Value of the property
+     * @param  {string} key Key as used for title of OSM Wiki.
      * @return {string} ons-list-item element
      */
-    getPropertyRow(name, value) {
+    getPropertyRow(name, value, key) {
+        var html = '';
         if (value) {
-            return '<ons-list-item modifier="nodivider"><div class="left list-item__title">' + name + '</div> <div class="right list-item__subtitle">' + value.replace(/_/g, ' ') + '</div></ons-list-item>';
+            html += '<ons-list-item modifier="nodivider"><div class="left list-item__title">';
+            if (key) {
+                html += '<a href="https://wiki.openstreetmap.org/wiki/Key%3A' + key + '">' + name + '</a>';
+            } else {
+                html += name;
+            }
+            html += '</div> <div class="right list-item__subtitle">' + value.replace(/_/g, ' ') + '</div></ons-list-item>';
         }
-        return '';
+        return html;
     }
 
     /**
@@ -157,15 +167,41 @@ export default class Popup {
      * @return {string} Set of tr elements
      */
     getPopupRows() {
-        let rows = this.getPropertyRow('Vegan', this.tags['diet:vegan']) +
-            this.getPropertyRow('Vegetarian', this.tags['diet:vegetarian']);
+        let rows = '';
 
+        // Cuisine and food-related metadata.
         if (this.tags.cuisine) {
-            rows += this.getPropertyRow('Cuisine', this.tags.cuisine.replace(/;/g, ', '));
+            rows += this.getPropertyRow('Cuisine', this.tags.cuisine.replace(/;/g, ', '), 'cuisine');
+        }
+        if (this.tags['diet:vegan']) {
+            rows += this.getPropertyRow('Vegan', this.tags['diet:vegan'], 'diet');
+        }
+        if (this.tags['diet:vegetarian']) {
+            rows += this.getPropertyRow('Vegetarian', this.tags['diet:vegetarian'], 'diet');
+        }
+        if (this.tags.takeaway) {
+            rows += this.getPropertyRow('Take away', this.tags.takeaway, 'takeaway');
         }
 
-        rows += this.getPropertyRow('Take away', this.tags.takeaway) +
-            this.getAddressRow() +
+        // Toilet facility metadata.
+        if (this.tags.changing_table) {
+            rows += this.getPropertyRow('Baby changing table', this.tags.changing_table, 'changing_table');
+        }
+        if (this.tags['toilets:access']) {
+            rows += this.getPropertyRow('Toilet access policy', this.tags['toilets:access'], 'access');
+        }
+        if (this.tags['toilets:gender_segregated']) { // A rare but sometimes used tag.
+            rows += this.getPropertyRow('Gender segregated', this.tags['toilets:gender_segregated'], 'gender_segregated');
+        }
+        if (this.tags['toilets:unisex']) {
+            rows += this.getPropertyRow('Unisex', this.tags['toilets:unisex'], 'unisex');
+        }
+        if (this.tags['toilets:wheelchair']) {
+            rows += this.getPropertyRow('Wheelchair accessible toilet', this.tags['toilets:wheelchair'], 'wheelchair');
+        }
+
+        // Basic information.
+        rows += this.getAddressRow() +
             this.getPhoneRow() +
             this.getWebsiteRow() +
             this.getOpeningHoursBtn() +


### PR DESCRIPTION
This pull request suggests adding a third parameter to the `getPropertyRows()` method of the markup popups allowing us to pass in a tag's key as used by the OSM Wiki to help a visitor understand the data being shown to them. It also suggests adding some useful and relevant tags to the rows displayed, notably `toilet:` related metadata (which is obviously critical to know about places you are going to eat and/or drink at).