### PR TITLE
#118 Do not retrieve disused shops and amenities from overpass API

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -38,7 +38,7 @@ const routingProviders = {
     openroute: 'https://openrouteservice.org/directions?a=null,null,{LAT},{LON}'
 };
 let overpassLayer;
-const overpassQuery = 'nwr({{bbox}})[~"^diet:.*$"~"."];out center;';
+const overpassQuery = 'nwr({{bbox}})[!"disused:shop"][!"disused:amenity"][~"^diet:.*$"~"."];out center;';
 
 /**
  * Open a dialog.


### PR DESCRIPTION
Update the query of Overpass API in order to leave out shops and amenities that are noted disused.

Closes #118 